### PR TITLE
User refuses proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ http://freelancer-finder-90193.herokuapp.com
 - [x] Criação de conta (usuário e profissional)
 - [x] Profissional completa perfil
 - [x] Profissional faz/cancela proposta em projeto
-- [ ] Usuário aceita/rejeita propostas
+- [x] Usuário rejeita propostas
+- [ ] Usuário aceita propostas
 - [ ] Usuário encerra inscrições para projeto
 - [ ] Visualizar time do projeto
 - [ ] Fornecer feedback após o projeto (usuário e profissional)
@@ -83,3 +84,16 @@ rails server
 ```
 rspec
 ```
+
+## Outras informações
+
+### Sobre cancelamento de propostas
+- Para cancelar uma proposta aprovada, o profissional deve apresentar um motivo
+- Um profissional não pode cancelar uma proposta após 3 dias da sua aprovação
+- Usuário não vê propostas canceladas enquanto pendentes, mas vê propostas com motivo de cancelamento (cancelada após ser aprovada)
+
+### Sobre recusa de propostas
+- Para recusar uma proposta, um usuário deve apresentar um motivo
+- Propostas recusadas não serão vistas pelo usuário, mas serão vistas pelo profissional junto com motivo de recusa
+- Não é possível modificar uma proposta recusada
+- Um profissional não pode criar novas propostas em um projeto em que teve uma proposta recusada

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -34,3 +34,7 @@ body {
 .card.border-canceled_approved {
   border: 2px solid red;
 }
+
+.card.border-refused {
+  border: 2px solid red;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,32 @@ class ApplicationController < ActionController::Base
     redirect_to edit_professional_registration_path(current_professional)
   end
 
+  def verify_duplicated_or_refused_proposal
+    proposal = current_professional
+               .not_canceled_proposals
+               .find_by(project_id: params[:project_id])
+
+    return unless proposal
+
+    flash[:alert] = 'Você já fez uma proposta nesse projeto'
+    if proposal.refused?
+      flash[:alert] = 'Você já tem uma proposta recusada nesse projeto'
+    end
+
+    redirect_to project_path(params[:project_id])
+  end
+
+  def verify_refused_proposal_modification
+    @proposal = current_professional.proposals.find(
+      params[:id] || params[:proposal_id]
+    )
+
+    return unless @proposal.refused?
+
+    flash[:alert] = 'Propostas recusadas não podem ser alteradas'
+    redirect_to @proposal.project
+  end
+
   def render_not_found(_exception)
     render file: Rails.root.join('public/404.html'), status: :not_found
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,13 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  def should_authenticate!
+    return if professional_signed_in? || user_signed_in?
+
+    flash[:alert] = 'Você deve estar logado.'
+    redirect_to root_path
+  end
+
   def redirect_professional_to_complete_profile
     return if current_professional.completed_profile?
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -66,13 +66,6 @@ class ProjectsController < ApplicationController
                                     :value_per_hour, :due_date, :remote)
   end
 
-  def should_authenticate!
-    return if professional_signed_in? || user_signed_in?
-
-    flash[:alert] = 'Você deve estar logado.'
-    redirect_to root_path
-  end
-
   def find_project_and_proposals_for_professional
     @project = Project.find(params[:id])
     @proposal = current_professional.not_canceled_proposals
@@ -81,6 +74,8 @@ class ProjectsController < ApplicationController
 
   def find_project_and_proposals_for_user
     @project = current_user.projects.find(params[:id])
-    @proposals = @project.proposals.where.not(status: :canceled_pending)
+    @proposals = @project.proposals.where.not(
+      status: %i[canceled_pending refused]
+    )
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -27,8 +27,7 @@ class ProposalsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @proposal.update(proposal_params)
@@ -73,10 +72,11 @@ class ProposalsController < ApplicationController
   end
 
   def verify_duplicated_or_refused_proposal
-    duplicated_proposal = current_professional.not_canceled_proposals
-                           .find_by(project_id: params[:project_id])
+    duplicated_proposal = current_professional
+                          .not_canceled_proposals
+                          .find_by(project_id: params[:project_id])
 
-    if duplicated_proposal && duplicated_proposal.refused?
+    if duplicated_proposal&.refused?
       flash[:alert] = 'Você já tem uma proposta recusada nesse projeto'
       redirect_to project_path(params[:project_id])
     elsif duplicated_proposal
@@ -90,10 +90,10 @@ class ProposalsController < ApplicationController
       params[:id] || params[:proposal_id]
     )
 
-    if @proposal.refused?
-      flash[:alert] = 'Propostas recusadas não podem ser alteradas'
-      redirect_to @proposal.project
-    end
+    return unless @proposal.refused?
+
+    flash[:alert] = 'Propostas recusadas não podem ser alteradas'
+    redirect_to @proposal.project
   end
 
   def cancel_reason_params
@@ -119,13 +119,13 @@ class ProposalsController < ApplicationController
   def user_refuse_proposal
     @proposal = Proposal.find_by!(id: params[:id],
                                   project: [current_user.projects])
-    
+
     if @proposal.refuse!(params[:proposal][:refuse_reason])
       flash[:notice] = 'Proposta recusada com sucesso'
     else
       flash[:alert] = 'Não é possível recusar essa proposta'
     end
-    
+
     redirect_to project_path(@proposal.project)
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -104,8 +104,13 @@ class ProposalsController < ApplicationController
   def user_refuse_proposal
     @proposal = Proposal.find_by!(id: params[:id],
                                   project: [current_user.projects])
-    @proposal.refuse!(params[:proposal][:refuse_reason])
-
-    redirect_to project_path(@proposal.project)
+    
+    if @proposal.refuse!(params[:proposal][:refuse_reason])
+      flash[:notice] = 'Proposta recusada com sucesso'
+      redirect_to project_path(@proposal.project)
+    else
+      flash[:alert] = 'Não é possível recusar essa proposta'
+      redirect_to project_path(@proposal.project), status: 400
+    end
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -48,10 +48,13 @@ class Proposal < ApplicationRecord
 
   # TODO: testar metodo
   def refuse!(refuse_reason = '')
+    return false if canceled_pending? || canceled_approved? || refused?
+
     refused!
     self.proposal_refusal = ProposalRefusal
                             .new(refuse_reason: refuse_reason)
-    save!
+
+    save
   end
 
   private

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -46,7 +46,6 @@ class Proposal < ApplicationRecord
     false
   end
 
-  # TODO: testar metodo
   def refuse!(refuse_reason = '')
     return false if canceled_pending? || canceled_approved? || refused?
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -38,6 +38,8 @@ class Proposal < ApplicationRecord
   end
 
   def can_cancel_at_current_date?
+    return false if canceled_pending? || canceled_approved? || refused?
+
     return true if approved? && Date.current < (approved_at + 3.days).to_date
 
     errors.add(:approved_at, "#{I18n.l approved_at.to_date}. "\

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -2,13 +2,15 @@ class Proposal < ApplicationRecord
   belongs_to :project
   belongs_to :professional
   has_one :proposal_cancelation, dependent: :destroy
+  has_one :proposal_refusal, dependent: :destroy
 
   enum status: {
     pending: 0,
     analyzing: 10,
     approved: 20,
     canceled_pending: 30,
-    canceled_approved: 40
+    canceled_approved: 40,
+    refused: 50
   }
 
   validates :message, :value_per_hour, :hours_per_week, :finish_date,
@@ -42,6 +44,14 @@ class Proposal < ApplicationRecord
                              'Não é possível cancelar a proposta após 3 dias.')
 
     false
+  end
+
+  # TODO: testar metodo
+  def refuse!(refuse_reason = '')
+    refused!
+    self.proposal_refusal = ProposalRefusal
+                            .new(refuse_reason: refuse_reason)
+    save!
   end
 
   private

--- a/app/models/proposal_refusal.rb
+++ b/app/models/proposal_refusal.rb
@@ -1,0 +1,3 @@
+class ProposalRefusal < ApplicationRecord
+  belongs_to :proposal
+end

--- a/app/views/projects/my_projects.html.erb
+++ b/app/views/projects/my_projects.html.erb
@@ -6,11 +6,6 @@
 <% end %>
 
 <div>
-  <!--
-  <div>
-    <h2>Meus projetos</h2>
-  </div>
-  -->
   <div>
     <h2>Minhas propostas</h2>
     <div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -13,6 +13,7 @@
   <% else %>
     <p>Esse projeto ainda não recebeu propostas</p>
   <% end %>
+
 <% elsif professional_signed_in? %>
   <% if @proposal %>
     <h2>Sua proposta</h2>
@@ -21,4 +22,5 @@
     <%= link_to 'Fazer proposta', new_project_proposal_path(@project),
     class: 'btn btn-primary' %>
   <% end %>
+
 <% end %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -55,7 +55,7 @@
 
     <% if user_signed_in? && !proposal.canceled_approved? %>
       <div>
-        <%= link_to 'Recusar', proposal_refuse_path(proposal) %>
+        <%= link_to 'Recusar', proposal_refuse_path(proposal), class: 'btn btn-danger' %>
       </div>
     <% end %>
   </div>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -48,5 +48,10 @@
       </div>
     <% end %>
 
+    <% if user_signed_in? %>
+      <div>
+        <%= link_to 'Recusar', proposal_refuse_path(proposal) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -23,6 +23,11 @@
           Motivo de cancelamento: <br>
           <%= proposal.proposal_cancelation.cancel_reason %>
         </p>
+      <% elsif proposal.refused? %>
+        <p>
+          Motivo de recusa: <br>
+          <%= proposal.proposal_refusal.refuse_reason %>
+        </p>
       <% end %>
     </div>
 
@@ -33,7 +38,7 @@
       <p>Expectativa de conclusão: <%= I18n.l proposal.finish_date %></p>
     </div>
 
-    <% if professional_signed_in? %>
+    <% if professional_signed_in? && !proposal.refused? %>
       <div>
         <%= link_to 'Editar', edit_proposal_path(proposal), class: 'btn btn-primary' %> 
 
@@ -48,7 +53,7 @@
       </div>
     <% end %>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && !proposal.canceled_approved? %>
       <div>
         <%= link_to 'Recusar', proposal_refuse_path(proposal) %>
       </div>

--- a/app/views/proposals/refuse.html.erb
+++ b/app/views/proposals/refuse.html.erb
@@ -9,6 +9,9 @@
     
     <br>
     <div class="actions">
+      <small class="text-danger">
+        O profissional não poderá criar novas propostas nesse projeto
+      </small>
       <%= f.submit 'Recusar proposta', class: "w-100 btn btn-lg btn-danger" %>
     </div>
   <% end %>

--- a/app/views/proposals/refuse.html.erb
+++ b/app/views/proposals/refuse.html.erb
@@ -1,15 +1,15 @@
 <main class="form-signin text-center">
   <%= form_with model: @proposal, method: :delete do |f| %>
     <div>
-      <%= f.label :cancel_reason, 'Informe por que quer cancelar a proposta:',
+      <%= f.label :refuse_reason, 'Informe por que quer recusar a proposta:',
         class: 'h4 mb-3 fw-normal' %>
       <br>
-      <%= f.text_area :cancel_reason, class: 'form-control', rows: '5' %>
+      <%= f.text_area :refuse_reason, class: 'form-control', rows: '5' %>
     </div>
     
     <br>
     <div class="actions">
-      <%= f.submit 'Cancelar proposta', class: "w-100 btn btn-lg btn-danger" %>
+      <%= f.submit 'Recusar proposta', class: "w-100 btn btn-lg btn-danger" %>
     </div>
   <% end %>
 </main>

--- a/config/locales/proposal_refusals.pt-BR.yml
+++ b/config/locales/proposal_refusals.pt-BR.yml
@@ -1,0 +1,8 @@
+---
+pt-BR:
+  activerecord:
+    models:
+      proposal_refusal: "Recusa"
+    attributes:
+      proposal_refusal:
+        refuse_reason: "Motivo de Recusa"

--- a/config/locales/proposals.pt-BR.yml
+++ b/config/locales/proposals.pt-BR.yml
@@ -15,4 +15,5 @@ pt-BR:
           approved: "Aprovada"
           canceled_pending: "Cancelada"
           canceled_approved: "Cancelada"
+          refused: "Recusada"
         approved_at: "Aprovada em"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   resources :proposals, only: [:edit, :update, :destroy] do
     get '/cancel', to: 'proposals#cancel'
+    get '/refuse', to: 'proposals#refuse'
   end
 
   resources :professionals, only: [:show]

--- a/db/migrate/20220112194536_create_proposal_refusals.rb
+++ b/db/migrate/20220112194536_create_proposal_refusals.rb
@@ -1,0 +1,10 @@
+class CreateProposalRefusals < ActiveRecord::Migration[6.1]
+  def change
+    create_table :proposal_refusals do |t|
+      t.text :refuse_reason, default: ""
+      t.references :proposal, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_24_004424) do
+ActiveRecord::Schema.define(version: 2022_01_12_194536) do
 
   create_table "professionals", force: :cascade do |t|
     t.string "name", default: "", null: false
@@ -54,6 +54,14 @@ ActiveRecord::Schema.define(version: 2021_10_24_004424) do
     t.index ["proposal_id"], name: "index_proposal_cancelations_on_proposal_id"
   end
 
+  create_table "proposal_refusals", force: :cascade do |t|
+    t.text "refuse_reason", default: ""
+    t.integer "proposal_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["proposal_id"], name: "index_proposal_refusals_on_proposal_id"
+  end
+
   create_table "proposals", force: :cascade do |t|
     t.text "message", default: "", null: false
     t.decimal "value_per_hour", default: "0.0", null: false
@@ -84,6 +92,7 @@ ActiveRecord::Schema.define(version: 2021_10_24_004424) do
 
   add_foreign_key "projects", "users"
   add_foreign_key "proposal_cancelations", "proposals"
+  add_foreign_key "proposal_refusals", "proposals"
   add_foreign_key "proposals", "professionals"
   add_foreign_key "proposals", "projects"
 end

--- a/db/seeds/development/04_proposals.rb
+++ b/db/seeds/development/04_proposals.rb
@@ -62,3 +62,16 @@ proposal_6 = Proposal.create!({
   professional_id: 1,
   approved_at: Time.current - 3.day
 })
+
+proposal_7 = Proposal.create!({
+  message: 'Refused',
+  value_per_hour: 1,
+  hours_per_week: 1,
+  finish_date: Time.current + 3.day,
+  status: :refused,
+  project_id: 3,
+  professional_id: 1,
+  proposal_refusal: ProposalRefusal.new({
+    refuse_reason: 'Nobis totam perspiciatis repudiandae distinctio dolor'
+  })
+})

--- a/db/seeds/production/04_proposals.rb
+++ b/db/seeds/production/04_proposals.rb
@@ -62,3 +62,16 @@ proposal_6 = Proposal.create!({
   professional_id: 1,
   approved_at: Time.current - 3.day
 })
+
+proposal_7 = Proposal.create!({
+  message: 'Refused',
+  value_per_hour: 1,
+  hours_per_week: 1,
+  finish_date: Time.current + 3.day,
+  status: :refused,
+  project_id: 3,
+  professional_id: 1,
+  proposal_refusal: ProposalRefusal.new({
+    refuse_reason: 'Nobis totam perspiciatis repudiandae distinctio dolor'
+  })
+})

--- a/spec/factories/proposal_refusals.rb
+++ b/spec/factories/proposal_refusals.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :proposal_refusal do
+    refuse_reason { 'MyText' }
+    proposal { nil }
+  end
+end

--- a/spec/models/proposal_refusal_spec.rb
+++ b/spec/models/proposal_refusal_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProposalRefusal, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/proposal_refusal_spec.rb
+++ b/spec/models/proposal_refusal_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe ProposalRefusal, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to :proposal }
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Proposal, type: :model do
     should define_enum_for(:status)
       .with_values(
         pending: 0, analyzing: 10, approved: 20, canceled_pending: 30,
-        canceled_approved: 40
+        canceled_approved: 40, refused: 50
       )
   }
   it { should validate_presence_of :message }

--- a/spec/requests/professional/professional_authentication_spec.rb
+++ b/spec/requests/professional/professional_authentication_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Professional authentication' do
-  it 'must complete profile to view projects' do
+  it 'should complete profile to view projects' do
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
                         password: '123456')
     Project.create!(
@@ -17,7 +17,7 @@ describe 'Professional authentication' do
     expect(response).to redirect_to('/professionals/edit.1')
   end
 
-  it 'must be signed in to create proposal' do
+  it 'should be signed in to create proposal' do
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
                         password: '123456')
     Project.create!(
@@ -41,7 +41,7 @@ describe 'Professional authentication' do
     expect(Proposal.count).to eq(0)
   end
 
-  it 'can not view edit page of another professional\'s proposal' do
+  it 'should not view edit page of another professional\'s proposal' do
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
                         password: '123456')
     pj1 = Project.create!(
@@ -68,7 +68,7 @@ describe 'Professional authentication' do
     expect(response).to have_http_status(:not_found)
   end
 
-  it 'can not update another professional\'s proposal' do
+  it 'should not update another professional\'s proposal' do
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
                         password: '123456')
     pj1 = Project.create!(
@@ -102,5 +102,35 @@ describe 'Professional authentication' do
     }
 
     expect(response).to have_http_status(:not_found)
+  end
+
+  it 'should not view proposal refuse form' do
+    proposal = create(:proposal)
+
+    login_as proposal.professional, scope: :professional
+    get '/proposals/1/refuse'
+
+    follow_redirect!
+    expect(response).to redirect_to(root_path)
+  end
+
+  it 'should not update refused proposal' do
+    proposal = create(:proposal)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refused!')
+
+    login_as proposal.professional, scope: :professional
+    put '/proposals/1', params: {
+      proposal: {
+        message: 'Should not be updated',
+        value_per_hour: 10,
+        hours_per_week: 10,
+        finish_date: Time.current + 3.days
+      }
+    }
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(response).to have_http_status(400)
+    expect(flash[:alert]).to eq('smth')
   end
 end

--- a/spec/requests/professional/professional_authentication_spec.rb
+++ b/spec/requests/professional/professional_authentication_spec.rb
@@ -113,24 +113,4 @@ describe 'Professional authentication' do
     follow_redirect!
     expect(response).to redirect_to(root_path)
   end
-
-  it 'should not update refused proposal' do
-    proposal = create(:proposal)
-    proposal.refused!
-    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refused!')
-
-    login_as proposal.professional, scope: :professional
-    put '/proposals/1', params: {
-      proposal: {
-        message: 'Should not be updated',
-        value_per_hour: 10,
-        hours_per_week: 10,
-        finish_date: Time.current + 3.days
-      }
-    }
-
-    expect(Proposal.first.status).to eq('refused')
-    expect(response).to have_http_status(400)
-    expect(flash[:alert]).to eq('smth')
-  end
 end

--- a/spec/requests/professional/professional_cancel_proposal_spec.rb
+++ b/spec/requests/professional/professional_cancel_proposal_spec.rb
@@ -89,4 +89,25 @@ describe 'Professional cancel proposal' do
     expect(response).to redirect_to(project_path proposal.project)
     expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
+
+  it 'and should not cancel if already canceled_pending' do
+    proposal = create(:proposal)
+    proposal.canceled_pending!
+
+    login_as proposal.professional, scope: :professional
+    delete '/proposals/1'
+
+    expect(Proposal.first.status).to eq('canceled_pending')
+  end
+
+  it 'and should not cancel if already canceled_approved' do
+    proposal = create(:proposal)
+    proposal.canceled_approved!
+    ProposalCancelation.create!(proposal: proposal, cancel_reason: 'Cancel')
+
+    login_as proposal.professional, scope: :professional
+    delete '/proposals/1'
+
+    expect(Proposal.first.status).to eq('canceled_approved')
+  end
 end

--- a/spec/requests/professional/professional_cancel_proposal_spec.rb
+++ b/spec/requests/professional/professional_cancel_proposal_spec.rb
@@ -72,7 +72,7 @@ describe 'Professional cancel proposal' do
     get '/proposals/1/cancel'
 
     expect(Proposal.first.status).to eq('refused')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
 
@@ -86,7 +86,7 @@ describe 'Professional cancel proposal' do
     delete '/proposals/1'
 
     expect(Proposal.first.status).to eq('refused')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
 

--- a/spec/requests/professional/professional_cancel_proposal_spec.rb
+++ b/spec/requests/professional/professional_cancel_proposal_spec.rb
@@ -32,26 +32,9 @@ describe 'Professional cancel proposal' do
     expect(flash[:notice]).to eq('Proposta cancelada com sucesso')
   end
 
-  it 'should not cancel approved proposal after three days' do
-    jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
-                        password: '123456')
-    pj1 = Project.create!(
-      title: 'Projeto 1', description: 'lorem ipsum...',
-      desired_abilities: 'design', value_per_hour: 12.34,
-      due_date: '09/10/2021', remote: true, creator: jane
-    )
-    professional = create(:completed_profile_professional)
-    prop1 = Proposal.create!(
-      message: 'John\'s proposal on project 1',
-      value_per_hour: 80.80,
-      hours_per_week: 20,
-      finish_date: 3.days.from_now,
-      status: :approved,
-      approved_at: '10/10/2021',
-      project: pj1,
-      professional: professional
-    )
-    login_as professional, scope: :professional
+  it 'and should not cancel approved proposal after three days' do
+    proposal = create(:proposal, status: :approved, approved_at: '10/10/2021')
+    login_as proposal.professional, scope: :professional
 
     delete '/proposals/1', params: {
       proposal: {
@@ -59,7 +42,7 @@ describe 'Professional cancel proposal' do
       }
     }
 
-    travel_to prop1.approved_at + 3.days do
+    travel_to proposal.approved_at + 3.days do
       expect(response.body).to include(
         'Aprovada em 10/10/2021. '\
         'Não é possível cancelar a proposta após 3 dias.'
@@ -68,30 +51,42 @@ describe 'Professional cancel proposal' do
     end
   end
 
-  it 'should not view cancel form if is pending' do
-    jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
-                        password: '123456')
-    pj1 = Project.create!(
-      title: 'Projeto 1', description: 'lorem ipsum...',
-      desired_abilities: 'design', value_per_hour: 12.34,
-      due_date: '09/10/2021', remote: true, creator: jane
-    )
-    professional = create(:completed_profile_professional)
-    Proposal.create!(
-      message: 'John\'s proposal on project 1',
-      value_per_hour: 80.80,
-      hours_per_week: 20,
-      finish_date: 3.days.from_now,
-      status: :pending,
-      project: pj1,
-      professional: professional
-    )
-    login_as professional, scope: :professional
+  it 'and should not view cancel form if is pending' do
+    proposal = create(:proposal)
+    login_as proposal.professional, scope: :professional
 
     get '/proposals/1/cancel'
 
     expect(response).to redirect_to('/projects/my')
     expect(flash[:notice]).to eq('Proposta cancelada com sucesso')
     expect(Proposal.first.status).to eq('canceled_pending')
+  end
+
+  it 'and should not see cancel form if refused' do
+    proposal = create(:proposal)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refused!')
+
+    login_as proposal.professional, scope: :professional
+
+    get '/proposals/1/cancel'
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(response).to redirect_to(project_path proposal.project)
+    expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
+  end
+
+  it 'and should not cancel if refused' do
+    proposal = create(:proposal)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refused!')
+
+    login_as proposal.professional, scope: :professional
+
+    delete '/proposals/1'
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(response).to redirect_to(project_path proposal.project)
+    expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
 end

--- a/spec/requests/professional/professional_creates_proposal_spec.rb
+++ b/spec/requests/professional/professional_creates_proposal_spec.rb
@@ -184,6 +184,6 @@ describe 'Professional creates proposal' do
 
     expect(Proposal.first.status).to eq('refused')
     expect(response).to redirect_to(project_path proposal.project)
-    expect(flash[:alert]).to eq('Esta proposta não pode ser editada')
+    expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
 end

--- a/spec/requests/professional/professional_creates_proposal_spec.rb
+++ b/spec/requests/professional/professional_creates_proposal_spec.rb
@@ -178,12 +178,12 @@ describe 'Professional creates proposal' do
         message: 'Should not be updated',
         value_per_hour: 10,
         hours_per_week: 10,
-        finish_date: Time.current + 3.days
+        finish_date: 3.days.from_now
       }
     }
 
     expect(Proposal.first.status).to eq('refused')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Propostas recusadas não podem ser alteradas')
   end
 
@@ -202,7 +202,7 @@ describe 'Professional creates proposal' do
     }
 
     expect(Proposal.count).to eq(1)
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq(
       'Você já tem uma proposta recusada nesse projeto'
     )
@@ -218,7 +218,7 @@ describe 'Professional creates proposal' do
     get '/projects/1/proposals/new'
 
     expect(Proposal.count).to eq(1)
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq(
       'Você já tem uma proposta recusada nesse projeto'
     )

--- a/spec/requests/professional/professional_creates_proposal_spec.rb
+++ b/spec/requests/professional/professional_creates_proposal_spec.rb
@@ -166,4 +166,24 @@ describe 'Professional creates proposal' do
     expect(flash[:notice]).to eq('Proposta criada com sucesso')
     expect(response).to redirect_to(project_path(pj1))
   end
+
+  it 'should not update refused proposal' do
+    proposal = create(:proposal)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refused!')
+
+    login_as proposal.professional, scope: :professional
+    put '/proposals/1', params: {
+      proposal: {
+        message: 'Should not be updated',
+        value_per_hour: 10,
+        hours_per_week: 10,
+        finish_date: Time.current + 3.days
+      }
+    }
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(response).to redirect_to(project_path proposal.project)
+    expect(flash[:alert]).to eq('Esta proposta não pode ser editada')
+  end
 end

--- a/spec/requests/user/user_authentication_spec.rb
+++ b/spec/requests/user/user_authentication_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'User authentication' do
-  it 'can not create projects without sign in' do
+  it 'should not create projects without sign in' do
     get '/projects/new'
 
     expect(response).to redirect_to('/users/sign_in')
@@ -29,7 +29,7 @@ describe 'User authentication' do
     expect(response).to redirect_to('/')
   end
 
-  it 'can not view edit page of another user\'s project' do
+  it 'should not view edit page of another user\'s project' do
     john = User.create!(name: 'John Doe', email: 'john.doe@email.com',
                         password: '123456')
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
@@ -51,7 +51,7 @@ describe 'User authentication' do
     expect(response).to have_http_status(:not_found)
   end
 
-  it 'can not update another user\'s project' do
+  it 'should not update another user\'s project' do
     john = User.create!(name: 'John Doe', email: 'john.doe@email.com',
                         password: '123456')
     jane = User.create!(name: 'Jane Doe', email: 'jane.doe@email.com',
@@ -82,7 +82,7 @@ describe 'User authentication' do
     expect(response).to have_http_status(:not_found)
   end
 
-  it 'can not create proposal' do
+  it 'should not create proposal' do
     john = User.create!(name: 'John Doe', email: 'john.doe@email.com',
                         password: '123456')
     Project.create!(

--- a/spec/requests/user/user_refuses_proposal_spec.rb
+++ b/spec/requests/user/user_refuses_proposal_spec.rb
@@ -82,7 +82,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('canceled_approved')
-    expect(response).to have_http_status(400)
+    expect(response).to redirect_to(project_path proposal.project)
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 
@@ -98,7 +98,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('canceled_pending')
-    expect(response).to have_http_status(400)
+    expect(response).to redirect_to(project_path proposal.project)
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 
@@ -115,7 +115,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('refused')
-    expect(response).to have_http_status(400)
+    expect(response).to redirect_to(project_path proposal.project)
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 end

--- a/spec/requests/user/user_refuses_proposal_spec.rb
+++ b/spec/requests/user/user_refuses_proposal_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'User refuses proposal' do
   it 'and should be signed in' do
-    proposal = create(:proposal)
+    create(:proposal)
 
     delete '/proposals/1', params: {
       proposal: {
@@ -62,7 +62,7 @@ describe 'User refuses proposal' do
 
   it 'and should not see refuse form for another user\'s project' do
     proposal1, = create_list(:proposal, 2)
-    
+
     login_as proposal1.project.creator, scope: :user
     get '/proposals/2/refuse'
 
@@ -82,7 +82,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('canceled_approved')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 
@@ -98,7 +98,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('canceled_pending')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 
@@ -115,7 +115,7 @@ describe 'User refuses proposal' do
     }
 
     expect(Proposal.first.status).to eq('refused')
-    expect(response).to redirect_to(project_path proposal.project)
+    expect(response).to redirect_to(project_path(proposal.project))
     expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 end

--- a/spec/requests/user/user_refuses_proposal_spec.rb
+++ b/spec/requests/user/user_refuses_proposal_spec.rb
@@ -1,6 +1,52 @@
 require 'rails_helper'
 
 describe 'User refuses proposal' do
+  it 'and should be signed in' do
+    proposal = create(:proposal)
+
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Should not refuse this'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('pending')
+    expect(response).to redirect_to(root_path)
+    expect(flash[:alert]).to eq('Você deve estar logado.')
+  end
+
+  it 'successfully if pending' do
+    proposal = create(:proposal)
+
+    login_as proposal.project.creator, scope: :user
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Refused'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(ProposalRefusal.first.refuse_reason).to eq('Refused')
+    expect(response).to redirect_to('/projects/1')
+    expect(flash[:notice]).to eq('Proposta recusada com sucesso')
+  end
+
+  it 'successfully if approved' do
+    proposal = create(:proposal, status: :approved, approved_at: Time.current)
+
+    login_as proposal.project.creator, scope: :user
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Refused!'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(ProposalRefusal.first.refuse_reason).to eq('Refused!')
+    expect(response).to redirect_to('/projects/1')
+    expect(flash[:notice]).to eq('Proposta recusada com sucesso')
+  end
+
   it 'and should not refuse proposal in another user\'s project' do
     proposal1, = create_list(:proposal, 2)
 
@@ -21,5 +67,55 @@ describe 'User refuses proposal' do
     get '/proposals/2/refuse'
 
     expect(response).to have_http_status(:not_found)
+  end
+
+  it 'and should not refuse canceled_approved proposal' do
+    proposal = create(:proposal, status: :approved, approved_at: Time.current)
+    proposal.canceled_approved!
+    ProposalCancelation.create!(proposal: proposal, cancel_reason: 'canceled')
+
+    login_as proposal.project.creator, scope: :user
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Should not refuse this'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('canceled_approved')
+    expect(response).to have_http_status(400)
+    expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
+  end
+
+  it 'and should not refuse canceled_pending proposal' do
+    proposal = create(:proposal)
+    proposal.canceled_pending!
+
+    login_as proposal.project.creator, scope: :user
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Should not refuse this'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('canceled_pending')
+    expect(response).to have_http_status(400)
+    expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
+  end
+
+  it 'and should not refuse refused proposal' do
+    proposal = create(:proposal)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'refused')
+
+    login_as proposal.project.creator, scope: :user
+    delete '/proposals/1', params: {
+      proposal: {
+        refuse_reason: 'Should not refuse this'
+      }
+    }
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(response).to have_http_status(400)
+    expect(flash[:alert]).to eq('Não é possível recusar essa proposta')
   end
 end

--- a/spec/requests/user/user_refuses_proposal_spec.rb
+++ b/spec/requests/user/user_refuses_proposal_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'User refuses proposal' do
+  it 'and should not refuse proposal in another user\'s project' do
+    proposal1, = create_list(:proposal, 2)
+
+    login_as proposal1.project.creator, scope: :user
+    delete '/proposals/2', params: {
+      proposal: {
+        refuse_reason: 'Should not refuse this'
+      }
+    }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'and should not see refuse form for another user\'s project' do
+    proposal1, = create_list(:proposal, 2)
+    
+    login_as proposal1.project.creator, scope: :user
+    get '/proposals/2/refuse'
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/system/user/user_refuses_proposal_spec.rb
+++ b/spec/system/user/user_refuses_proposal_spec.rb
@@ -62,9 +62,9 @@ describe 'User refuses proposal' do
     ProposalRefusal.create!(
       proposal: refused_proposal, refuse_reason: 'Refusado!'
     )
-    
+
     another_proposal = create(:proposal, project: project, message: 'Pending')
-    
+
     login_as project.creator, scope: :user
 
     visit project_path(project)
@@ -86,7 +86,7 @@ describe 'User refuses proposal' do
     expect(page).to have_content('Sua proposta')
     within '#proposal-1' do
       expect(page).to have_content("Mensagem: #{proposal.message}")
-      expect(page).to have_content("Status: Recusada")
+      expect(page).to have_content('Status: Recusada')
       expect(page).to have_content(
         "Motivo de recusa: #{proposal.proposal_refusal.refuse_reason}"
       )

--- a/spec/system/user/user_refuses_proposal_spec.rb
+++ b/spec/system/user/user_refuses_proposal_spec.rb
@@ -32,4 +32,97 @@ describe 'User refuses proposal' do
     expect(current_path).to eq('/projects/1')
     expect(page).to have_content('Esse projeto ainda não recebeu propostas')
   end
+
+  it 'and refuses proposal at professional profile' do
+    project = create(:project)
+    proposal = create(:proposal, project: project)
+    login_as project.creator, scope: :user
+
+    visit professional_path(proposal.professional)
+    within '#proposal-1' do
+      click_on 'Recusar'
+    end
+    fill_in 'Informe por que quer recusar a proposta:', with: 'Recusando'
+    click_on 'Recusar proposta'
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
+    expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Esse projeto ainda não recebeu propostas')
+  end
+
+  it 'and should not see refused proposal' do
+    project = create(:project)
+    refused_proposal = create(
+      :proposal, project: project, message: 'This is refused'
+    )
+    refused_proposal.refused!
+    ProposalRefusal.create!(
+      proposal: refused_proposal, refuse_reason: 'Refusado!'
+    )
+    
+    another_proposal = create(:proposal, project: project, message: 'Pending')
+    
+    login_as project.creator, scope: :user
+
+    visit project_path(project)
+    within '#proposal-2' do
+      expect(page).to have_content("Mensagem: #{another_proposal.message}")
+    end
+    expect(page).not_to have_content("Mensagem: #{refused_proposal.message}")
+  end
+
+  it 'and professional see refused proposal' do
+    project = create(:project)
+    proposal = create(:proposal, project: project)
+    proposal.refused!
+    ProposalRefusal.create!(proposal: proposal, refuse_reason: 'Refusado!')
+
+    login_as proposal.professional, scope: :professional
+
+    visit project_path(project)
+    expect(page).to have_content('Sua proposta')
+    within '#proposal-1' do
+      expect(page).to have_content("Mensagem: #{proposal.message}")
+      expect(page).to have_content("Status: Recusada")
+      expect(page).to have_content(
+        "Motivo de recusa: #{proposal.proposal_refusal.refuse_reason}"
+      )
+    end
+    expect(page).not_to have_link('Editar')
+    expect(page).not_to have_link('Fazer proposta')
+  end
+
+  it 'and should refuse approved proposal' do
+    project = create(:project)
+    proposal = create(:proposal, project: project)
+    proposal.approved!
+    login_as project.creator, scope: :user
+
+    visit project_path(project)
+    within '#proposal-1' do
+      click_on 'Recusar'
+    end
+    fill_in 'Informe por que quer recusar a proposta:', with: 'Recusando'
+    click_on 'Recusar proposta'
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
+    expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Esse projeto ainda não recebeu propostas')
+  end
+
+  it 'and should not refuse canceled_approved proposal' do
+    project = create(:project)
+    proposal = create(:proposal, project: project)
+    proposal.canceled_approved!
+    ProposalCancelation.create!(proposal: proposal, cancel_reason: 'Canceled')
+    login_as project.creator, scope: :user
+
+    visit project_path(project)
+    within '#proposal-1' do
+      expect(page).not_to have_link('Recusar')
+      expect(page).to have_content('Motivo de cancelamento: Canceled')
+    end
+  end
 end

--- a/spec/system/user/user_refuses_proposal_spec.rb
+++ b/spec/system/user/user_refuses_proposal_spec.rb
@@ -30,6 +30,7 @@ describe 'User refuses proposal' do
     expect(Proposal.first.status).to eq('refused')
     expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
     expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Proposta recusada com sucesso')
     expect(page).to have_content('Esse projeto ainda não recebeu propostas')
   end
 
@@ -48,6 +49,7 @@ describe 'User refuses proposal' do
     expect(Proposal.first.status).to eq('refused')
     expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
     expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Proposta recusada com sucesso')
     expect(page).to have_content('Esse projeto ainda não recebeu propostas')
   end
 
@@ -109,6 +111,7 @@ describe 'User refuses proposal' do
     expect(Proposal.first.status).to eq('refused')
     expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
     expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Proposta recusada com sucesso')
     expect(page).to have_content('Esse projeto ainda não recebeu propostas')
   end
 

--- a/spec/system/user/user_refuses_proposal_spec.rb
+++ b/spec/system/user/user_refuses_proposal_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'User refuses proposal' do
+  it 'and should see refuse reason page' do
+    project = create(:project)
+    create(:proposal, project: project)
+    login_as project.creator, scope: :user
+
+    visit project_path(project)
+    within '#proposal-1' do
+      click_on 'Recusar'
+    end
+
+    expect(current_path).to eq('/proposals/1/refuse')
+    expect(page).to have_content('Informe por que quer recusar a proposta:')
+  end
+
+  it 'successfully with reason' do
+    project = create(:project)
+    create(:proposal, project: project)
+    login_as project.creator, scope: :user
+
+    visit project_path(project)
+    within '#proposal-1' do
+      click_on 'Recusar'
+    end
+    fill_in 'Informe por que quer recusar a proposta:', with: 'Recusando'
+    click_on 'Recusar proposta'
+
+    expect(Proposal.first.status).to eq('refused')
+    expect(ProposalRefusal.first.refuse_reason).to eq('Recusando')
+    expect(current_path).to eq('/projects/1')
+    expect(page).to have_content('Esse projeto ainda não recebeu propostas')
+  end
+end


### PR DESCRIPTION
Usuário pode recusar propostas em seu projeto

- Propostas recusadas não serão vistas pelo usuário, mas serão vistas pelo profissional junto com motivo de recusa
- Não é possível modificar uma proposta recusada
- Um profissional não pode criar novas propostas em um projeto em que teve uma proposta recusada

Resolve #11 